### PR TITLE
Honour alignment in columns block

### DIFF
--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -3,8 +3,9 @@ export function applySplitPercentages(block) {
   for (let i = 0; i < block.classList.length; i += 1) {
     const cls = block.classList[i];
     if (cls.startsWith('split-')) {
-      const numbers = cls.substring(6);
-      numbers.split('-').forEach((n) => ratios.push(`${n}%`));
+      const varName = `--${cls}`;
+      const numbers = getComputedStyle(block).getPropertyValue(varName);
+      numbers.split(':').forEach((n) => ratios.push(n));
       break;
     }
   }

--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -31,6 +31,45 @@ export function applySplitPercentages(block) {
   }
 }
 
+function applyHorizontalCellAlignment(block) {
+  block.querySelectorAll(':scope div[data-align]').forEach((d) => {
+    if (d.classList.contains('text-col')) {
+      // This is a text column
+      if (d.dataset.align) {
+        d.style.textAlign = d.dataset.align;
+      }
+    } else {
+      // This is an image column
+      d.style.display = 'flex';
+      d.style.justifyContent = d.dataset.align;
+    }
+  });
+}
+
+// Vertical Cell Alignment is only applied to non-text columns
+function applyVerticalCellAlignment(block) {
+  block.querySelectorAll(':scope > div > div:not(.text-col-wrapper').forEach((d) => {
+    // this is an image column
+    d.style.display = 'flex';
+
+    switch (d.dataset.valign) {
+      case 'middle':
+        d.style.alignSelf = 'center';
+        break;
+      case 'bottom':
+        d.style.alignSelf = 'flex-end';
+        break;
+      default:
+        d.style.alignSelf = 'flex-start';
+    }
+  });
+}
+
+export function applyCellAlignment(block) {
+  applyHorizontalCellAlignment(block);
+  applyVerticalCellAlignment(block);
+}
+
 export default function decorate(block) {
   const background = block.classList.contains('backgroundimage');
   if (background) {
@@ -178,4 +217,5 @@ export default function decorate(block) {
   }
 
   applySplitPercentages(block);
+  applyCellAlignment(block);
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -126,6 +126,9 @@
   /* Font Sizes */
   --font-size-small: 14px;
   --font-size-xsmall: 12px;
+
+  /* Column Split Ratios */
+  --split-endorsement: 76%:24%;
 }
 
 html {

--- a/test/blocks/columns/columns.plain.html
+++ b/test/blocks/columns/columns.plain.html
@@ -1,5 +1,14 @@
+<head>
+    <style>
+        :root {
+          --split-testratio1: 80%:20%;
+          --split-testratio2: 30%:70%;
+         }
+    </style>
+</head>
+<body>
   <div>
-    <div class="columns split-80-20 native-image-sizes">
+    <div class="columns split-testratio1 native-image-sizes">
       <div>
         <div id="column-a" data-valign="middle">
         </div>
@@ -14,7 +23,7 @@
       </div>
     </div>
 
-    <div class="columns split-30-70 native-image-sizes">
+    <div class="columns split-testratio2 native-image-sizes">
       <div>
         <div class="text-col-wrapper">
           <div id="column-t1" class="text-col" data-valign="middle">
@@ -48,3 +57,4 @@
       </div>
     </div>
   </div>
+</body>

--- a/test/blocks/columns/columns.plain.html
+++ b/test/blocks/columns/columns.plain.html
@@ -3,21 +3,47 @@
       <div>
         <div id="column-a" data-valign="middle">
         </div>
-        <div id="column-b" data-valign="middle">
+        <div id="column-b" data-valign="bottom">
         </div>
       </div>
       <div>
-        <div id="column-x" data-valign="middle">
+        <div id="column-x" data-align="center">
         </div>
-        <div id="column-y" data-valign="middle">
+        <div id="column-y" data-align="right">
         </div>
       </div>
     </div>
+
+    <div class="columns split-30-70 native-image-sizes">
+      <div>
+        <div class="text-col-wrapper">
+          <div id="column-t1" class="text-col" data-valign="middle">
+          </div>
+        </div>
+        <div class="text-col-wrapper">
+          <div id="column-t2" class="text-col" data-valign="bottom">
+          </div>
+        </div>
+      </div>
+      <div>
+        <div class="text-col-wrapper">
+          <div id="column-t3" class="text-col" data-align="center">
+          </div>
+        </div>
+        <div class="text-col-wrapper">
+          <div id="column-t4" class="text-col" data-align="right">
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div class="columns other native-image-sizes">
       <div>
-        <div id="column-c" data-valign="middle">
+        <div id="column-c">
         </div>
-        <div id="column-d" data-valign="middle">
+        <div id="column-d" class="text-col-wrapper">
+          <div id="column-d2" class="text-col">
+          </div>
         </div>
       </div>
     </div>

--- a/test/blocks/columns/columns.test.js
+++ b/test/blocks/columns/columns.test.js
@@ -43,4 +43,65 @@ describe('Columns Block', () => {
     const cd = block.querySelector('#column-d');
     expect(cd.style.flexBasis).to.equal('');
   });
+
+  it('Applies alignment to non-text cells', () => {
+    const block = document.querySelector('.columns.split-80-20');
+
+    scripts.applyCellAlignment(block);
+
+    const ca = block.querySelector('#column-a');
+    expect(ca.style.display).to.equal('flex');
+    expect(ca.style.alignSelf).to.equal('center');
+
+    const cb = block.querySelector('#column-b');
+    expect(cb.style.display).to.equal('flex');
+    expect(cb.style.alignSelf).to.equal('flex-end');
+
+    const cx = block.querySelector('#column-x');
+    expect(cx.style.display).to.equal('flex');
+    expect(cx.style.justifyContent).to.equal('center');
+
+    const cy = block.querySelector('#column-y');
+    expect(cy.style.display).to.equal('flex');
+    expect(cy.style.justifyContent).to.equal('right');
+  });
+
+  it('Applies alignment to text cells', () => {
+    const block = document.querySelector('.columns.split-30-70');
+
+    scripts.applyCellAlignment(block);
+
+    const t1 = block.querySelector('#column-t1');
+    expect(t1.style.display).to.not.equal('flex');
+    expect(t1.style.textAlign).to.equal('');
+
+    const t2 = block.querySelector('#column-t2');
+    expect(t2.style.display).to.not.equal('flex');
+    expect(t1.style.textAlign).to.equal('');
+
+    const t3 = block.querySelector('#column-t3');
+    expect(t3.style.display).to.not.equal('flex');
+    expect(t3.style.textAlign).to.equal('center');
+
+    const t4 = block.querySelector('#column-t4');
+    expect(t4.style.display).to.not.equal('flex');
+    expect(t4.style.textAlign).to.equal('right');
+  });
+
+  it('Applies default alignment', () => {
+    const block = document.querySelector('.columns.other');
+
+    scripts.applyCellAlignment(block);
+
+    const cc = block.querySelector('#column-c');
+    expect(cc.style.display).to.equal('flex');
+    expect(cc.style.alignSelf).to.equal('flex-start');
+
+    const cd = block.querySelector('#column-d');
+    expect(cd.style.display).to.not.equal('flex');
+
+    const cd2 = block.querySelector('#column-d');
+    expect(cd2.style.display).to.not.equal('flex');
+    expect(cd2.style.textAlign).to.equal('');
+  });
 });

--- a/test/blocks/columns/columns.test.js
+++ b/test/blocks/columns/columns.test.js
@@ -19,7 +19,7 @@ describe('Columns Block', () => {
   });
 
   it('Handles split percentages', () => {
-    const block = document.querySelector('.columns.split-80-20');
+    const block = document.querySelector('.columns.split-testratio1');
 
     scripts.applySplitPercentages(block);
 
@@ -45,7 +45,7 @@ describe('Columns Block', () => {
   });
 
   it('Applies alignment to non-text cells', () => {
-    const block = document.querySelector('.columns.split-80-20');
+    const block = document.querySelector('.columns.split-testratio1');
 
     scripts.applyCellAlignment(block);
 
@@ -67,7 +67,7 @@ describe('Columns Block', () => {
   });
 
   it('Applies alignment to text cells', () => {
-    const block = document.querySelector('.columns.split-30-70');
+    const block = document.querySelector('.columns.split-testratio2');
 
     scripts.applyCellAlignment(block);
 


### PR DESCRIPTION
Cell alignment is honoured in the following way:

* text cells support horizontal alignment: left/center/right
* non-text (image) cells support horizontal alignment and vertical alignment top/middle/bottom

Unit tests included

Fixes: #7

Test URLs:
- Original: https://www.sunstar-foundation.org/en/
- Before: https://main--sunstar-foundation--hlxsites.hlx.live/_drafts/bosschae/testcolumns
- Before: https://main--sunstar-foundation--hlxsites.hlx.live/en/
- After: https://issue-7--sunstar-foundation--hlxsites.hlx.live/_drafts/bosschae/testcolumns
- After: https://issue-7--sunstar-foundation--hlxsites.hlx.live/en/

Will update the sidekick library once merged.