### PR TITLE
Fixed Header on Japanese Pages : broken & inconsistent

### DIFF
--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -54,7 +54,7 @@ export default async function decorate(block) {
 
   // fetch footer content
   const footerMeta = getMetadata('footer');
-  const footerPath = footerMeta || (getLanguage() === 'ja' ? '/footer' : `/${getLanguage()}/footer`);
+  const footerPath = footerMeta || (getLanguage() === 'jp' ? '/footer' : `/${getLanguage()}/footer`);
   const resp = await fetch(`${footerPath}.plain.html`, window.location.pathname.endsWith('/footer') ? { cache: 'reload' } : {});
 
   if (resp.ok) {

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -98,7 +98,7 @@ const navDecorators = { 'nav-top': decorateTopNav, 'nav-middle': decorateMiddleN
 export default async function decorate(block) {
   // fetch nav content
   const navMeta = getMetadata('nav');
-  const navPath = navMeta || (getLanguage() === 'ja' ? '/nav' : `/${getLanguage()}/nav`);
+  const navPath = navMeta || (getLanguage() === 'jp' ? '/nav' : `/${getLanguage()}/nav`);
   const resp = await fetch(`${navPath}.plain.html`);
   const navTreeResp = await fetch(`/nav-tree.json?sheet=${getLanguage()}`);
   const navTreeJson = await navTreeResp.json();

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -703,7 +703,7 @@ export function getFormattedDate(date, locale = 'en') {
         return `${month} ${day}, ${year}`;
       },
     },
-    ja: {
+    jp: {
       locale: 'ja-JP',
       options: { year: 'numeric', month: '2-digit', day: 'numeric' },
       format: (formattedDate) => {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -29,7 +29,7 @@ const SKIP_FROM_LCP = ['breadcrumb']; // add blocks that shouldn't ever be LCP c
 // search for at least these many blocks (post-skipping-non-candidates) to find LCP candidates
 const MAX_LCP_CANDIDATE_BLOCKS = 2;
 
-const LANGUAGES = new Set(['en', 'ja']);
+const LANGUAGES = new Set(['en', 'jp']);
 
 const MODAL_FRAGMENTS_PATH_SEGMENT = '/fragments/modals/';
 export const MODAL_FRAGMENTS_ANCHOR_SELECTOR = `a[href*="${MODAL_FRAGMENTS_PATH_SEGMENT}"]`;
@@ -56,7 +56,7 @@ export function getLanguageFromPath(pathname, resetCache = false) {
   }
 
   if (language === undefined) {
-    language = 'ja'; // default to Japanese
+    language = 'jp'; // default to Japanese
   }
 
   return language;
@@ -68,7 +68,7 @@ export function getLanguage(curPath = window.location.pathname, resetCache = fal
 
 export function getLanguangeSpecificPath(path) {
   const lang = getLanguage();
-  if (lang === 'ja') return path;
+  if (lang === 'jp') return path;
   return `/${lang}${path}`;
 }
 

--- a/test/blocks/news-banner/news-banner.test.js
+++ b/test/blocks/news-banner/news-banner.test.js
@@ -26,7 +26,7 @@ describe('News Block', () => {
     window.placeholders = {
       'translation-loaded': {},
       translation: {
-        ja: placeholders,
+        jp: placeholders,
       },
     };
 

--- a/test/blocks/tags/tags.test.js
+++ b/test/blocks/tags/tags.test.js
@@ -47,7 +47,7 @@ describe('Tags Block', () => {
     window.placeholders = {
       'translation-loaded': {},
       translation: {
-        ja: placeholders,
+        jp: placeholders,
       },
     };
 

--- a/test/scripts/scripts.test.js
+++ b/test/scripts/scripts.test.js
@@ -70,9 +70,9 @@ describe('Scripts', () => {
     lang = scripts.getLanguageFromPath('/de/foo');
     expect(lang).to.equal('en'); // Language already set, so reuse the value
     lang = scripts.getLanguageFromPath('/de/foo', true);
-    expect(lang).to.equal('ja'); // Defaults to Japanese for unknown language
+    expect(lang).to.equal('jp'); // Defaults to Japanese for unknown language
     lang = scripts.getLanguageFromPath('/foobar', true);
-    expect(lang).to.equal('ja'); // Defaults to Japanese
+    expect(lang).to.equal('jp'); // Defaults to Japanese
   });
 
   it('Paging widget 1', () => {


### PR DESCRIPTION
Fixed errors in the Header and ensured that the location key is now uniform throughout the entire Sunstar project. Specifically, changed it to `jp` instead of `ja`.

Fixes #53 

Test URLs:
- Original: https://www.sunstar-foundation.org/about-us
- Before: https://main--sunstar-foundation--hlxsites.hlx.live/about-us
- After: https://issue-53-v1--sunstar-foundation--hlxsites.hlx.live/about-us