### PR TITLE
Refactored image caption autoblocking + decorate buttons

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -66,14 +66,6 @@
   padding: 0;
 }
 
-.columns p.button-container {
-  display: inline;
-  align-items: flex-start;
-  flex-direction: column;
-  gap: 1rem;
-  width: 11rem;
-}
-
 .columns a.button.tertiary {
   background-color: unset;
   color: var(--tertiary);
@@ -243,10 +235,10 @@ div.img-col > video {
   width: 100%;
 }
 
-@media (min-width: 62rem) {
-  .columns.top-down.collapse > div {
-    gap: 1.5rem;
-  }
+.columns p.button-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
 }
 
 .columns.collapse.top-down.columns-2-cols {
@@ -400,19 +392,20 @@ div.img-col > video {
     margin-bottom: 7.5rem;
   }
 
+  .collapse > div {
+    flex-direction: column;
+  }
+
   .columns p.button-container {
-    flex-direction: row;
-    align-items: center;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
     gap: 2rem;
     width: unset;
   }
 
   .columns a.button.primary {
     min-width: 11rem;
-  }
-
-  .collapse > div {
-    flex-direction: column;
   }
 
   .columns > div > div {
@@ -430,6 +423,10 @@ div.img-col > video {
 
   .columns.small-margin > div {
     margin-bottom: 1.5rem;
+  }
+
+  .columns.top-down.collapse > div {
+    gap: 1.5rem;
   }
 
   .columns > div .img-col {
@@ -505,5 +502,17 @@ div.img-col > video {
   div.img-col > video {
     height: 469px;
     width: 469px;
+  }
+
+  .columns p.button-container {
+    display: flex;
+    align-items: flex-start;
+    flex-flow: row wrap;
+    gap: 1rem;
+    width: 100%;
+  }
+  
+  .columns p.button-container a.button.primary {
+    min-width: fit-content;
   }
 }

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -40,7 +40,8 @@
   margin-bottom: 1.25rem;
 }
 
-.columns:not(.native-image-sizes) img {
+.columns:not(.native-image-sizes) img,
+.columns:not(.native-image-sizes) div.image-collage.autoblocked {
   width: 100%;
 }
 
@@ -266,7 +267,9 @@ div.img-col > video {
   width: 100%;
 }
 
-.columns:not(.no-padding) > div > div:not(.columns-img-col) div:not(.img-col) {
+.columns:not(.no-padding) > div > div:not(.columns-img-col) div:not(.img-col),
+.columns:not(.no-padding) > div.img-col-wrapper > div.image-collage.autoblocked,
+.columns:not(.no-padding) > div > div.img-col-wrapper {
   padding: 0 1rem;
 }
 
@@ -274,12 +277,9 @@ div.img-col > video {
   margin-top: 3rem;
 }
 
-  .columns.plain-links.collapse.collapse-without-top-margin:not(.continuation)
-    > div
-    > div:first-child {
-    margin-top: 0;
-  }
-
+.columns.plain-links.collapse.collapse-without-top-margin:not(.continuation) > div > div:first-child {
+  margin-top: 0;
+}
 
 .columns.plain-links.collapse > div h6::after {
   content: "";

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -405,8 +405,6 @@ div.img-col > video {
     margin-bottom: 7.5rem;
   }
 
-
-
   .columns p.button-container {
     flex-direction: row;
     align-items: center;

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -385,6 +385,52 @@ div.img-col > video {
   padding: 2rem 0;
 }
 
+/* Text-image overlap View */
+.columns.text-and-image-in-column.overlap em a {
+  display: inline-flex;
+  width: 100%;
+  font-size: var(--body-font-size-xl);
+  color: var(--secondary);
+  border: 1px solid var(--secondary);
+  background-color: var(--white);
+  padding: 1rem 0;
+  font-weight: var(--font-weight-bold);
+  font-style: normal;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  text-decoration: none;
+  border-radius: 2px;
+}
+
+.columns.text-and-image-in-column.overlap .button-container {
+  position: absolute;
+  top: 30%;
+  left: 0;
+  right: 0;
+  margin: 0;
+  width: 100%;
+}
+
+.columns.text-and-image-in-column.overlap .button-container a {
+  background-color: unset;
+  color: var(--secondary);
+  font-size: var(--body-font-size-m);
+  padding: unset;
+  display: block;
+  margin: 0 -1.25rem;
+}
+
+.columns.text-and-image-in-column.overlap em a:hover {
+  color: var(--white);
+  background-color: var(--link-blue-color);
+  border-color: var(--link-blue-color);
+}
+
+.columns.text-and-image-in-column.overlap .button-container a:hover {
+  text-decoration: underline;
+}
+
 @media (min-width: 62rem) {
   .columns h2,
   .columns:not(.no-buttons) h3,
@@ -500,53 +546,6 @@ div.img-col > video {
     background-position: center;
   }
 
-  /* Column styles - Machine parts */
-  main .block.columns.machine-parts > div {
-    align-items: flex-start;
-    gap: 1rem;
-  }
-
-  main .block.columns.machine-parts .img-col {
-    flex: auto;
-    flex-basis: auto;
-  }
-
-  main .block.columns.machine-parts .text-col h1,
-  main .block.columns.machine-parts .text-col h2,
-  main .block.columns.machine-parts .text-col h3,
-  main .block.columns.machine-parts .text-col h4,
-  main .block.columns.machine-parts .text-col h5,
-  main .block.columns.machine-parts .text-col h6 {
-    text-align: left;
-    text-transform: none;
-  }
-
-  main .block.columns.machine-parts .text-col p {
-    margin-bottom: 1.5rem;
-  }
-
-  main .block.columns.machine-parts .text-col h6 {
-    font-size: var(--heading-font-size-xs);
-    margin-bottom: 1rem;
-    letter-spacing: 0.05em;
-    color: var(--light-black);
-  }
-
-  main .block.columns.machine-parts .text-col a {
-    margin-bottom: 14px;
-    line-height: 1;
-    display: inline-block;
-    width: 100%;
-    font-weight: 500;
-    font-size: var(--body-font-size-m);
-    text-decoration: none;
-  }
-
-  main .block.columns.machine-parts .text-col a > strong {
-    color: var(--light-black);
-    margin-right: 1rem;
-  }
-
   main .columns.history.invert-image-order-in-narrow-view > div,
   main .columns.invert-even-col-in-narrow-view > div:nth-child(even) {
     flex-direction: row;
@@ -560,62 +559,7 @@ div.img-col > video {
   .columns:not(.no-padding) > div > div:not(.columns-img-col) div:not(.img-col) {
     padding: 1rem 0;
   }
-}
 
-@media (min-width: 77rem) {
-  div.img-col > video {
-    height: 469px;
-    width: 469px;
-  }
-}
-
-/* Text-image overlap View */
-.columns.text-and-image-in-column.overlap em a {
-  display: inline-flex;
-  width: 100%;
-  font-size: var(--body-font-size-xl);
-  color: var(--secondary);
-  border: 1px solid var(--secondary);
-  background-color: var(--white);
-  padding: 1rem 0;
-  font-weight: var(--font-weight-bold);
-  font-style: normal;
-  align-items: center;
-  justify-content: center;
-  line-height: 1;
-  text-decoration: none;
-  border-radius: 2px;
-}
-
-.columns.text-and-image-in-column.overlap .button-container {
-  position: absolute;
-  top: 30%;
-  left: 0;
-  right: 0;
-  margin: 0;
-  width: 100%;
-}
-
-.columns.text-and-image-in-column.overlap .button-container a {
-  background-color: unset;
-  color: var(--secondary);
-  font-size: var(--body-font-size-m);
-  padding: unset;
-  display: block;
-  margin: 0 -1.25rem;
-}
-
-.columns.text-and-image-in-column.overlap em a:hover {
-  color: var(--white);
-  background-color: var(--link-blue-color);
-  border-color: var(--link-blue-color);
-}
-
-.columns.text-and-image-in-column.overlap .button-container a:hover {
-  text-decoration: underline;
-}
-
-@media (min-width: 62rem) {
   .columns.text-and-image-in-column.overlap .button-container a {
     font-size: var(--body-font-size-xl);
     margin: 0 1rem;
@@ -628,5 +572,11 @@ div.img-col > video {
   .columns :not(.table) h3 {
     font-size: var(--heading-font-size-m);
   }
+}
 
+@media (min-width: 77rem) {
+  div.img-col > video {
+    height: 469px;
+    width: 469px;
+  }
 }

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -256,15 +256,11 @@
   margin: 0 1rem;
 }
 
-/* both autoblocking options for bottom caption */
-.columns.history div.image-collage.autoblocked picture ~ em,
-.columns.history div.image-collage.autoblocked picture ~ p {
+.columns div.image-collage.autoblocked picture ~ *.image-caption {
   color: var(--steel-blue);
   font-size: var(--body-font-size-s);
   margin: 1rem 0;
-  text-align: center;
 }
-
 
 .columns.history
   div.image-collage.autoblocked

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -61,23 +61,8 @@
   font-size: var(--heading-font-size-ms);
 }
 
-.columns.history h6 {
-  color: var(--transparent-grey-color-2);
-  font-size: var(--heading-font-size-mxs);
-  font-weight: var(--font-weight-medium);
-  margin: 0 0 1rem;
-}
-
-.columns.history strong {
-  font-size: var(--heading-font-size-ms);
-}
-
 .columns.plain-links a.button {
   padding: 0;
-}
-
-.columns.history > div {
-  align-items: center;
 }
 
 .columns p.button-container {
@@ -129,14 +114,6 @@
   margin-top: 0;
 }
 
-.columns.history h2 {
-  border-bottom: 1px solid var(--primary);
-  margin-inline: 0;
-  margin-bottom: 1rem;
-  font-size: var(--heading-font-size-xl);
-  font-weight: var(--font-weight-small);
-}
-
 .columns.crop-image > div {
   align-items: stretch;
 }
@@ -177,7 +154,6 @@
   font-size: var(--body-font-size-l);
 }
 
-.columns.history.invert-image-order-in-narrow-view > div,
 .columns.invert-even-col-in-narrow-view > div:nth-child(even) {
   flex-direction: column-reverse;
 }
@@ -252,7 +228,7 @@
   object-fit: cover;
 }
 
-.columns:not(.history,.no-padding) > div div.non-singleton-img {
+.columns:not(.no-padding) > div div.non-singleton-img {
   margin: 0 1rem;
 }
 
@@ -260,29 +236,6 @@
   color: var(--steel-blue);
   font-size: var(--body-font-size-s);
   margin: 1rem 0;
-}
-
-.columns.history
-  div.image-collage.autoblocked
-  div.text-col:last-of-type,
-.columns.history
-  div.image-collage.autoblocked
-  div.img-col:last-of-type {
-  margin-top: 2rem;
-  display: flex;
-  flex-direction: column;
-}
-
-
-.columns.history
-  div.image-collage.autoblocked
-  div.text-col:last-of-type
-  picture,
-.columns.history
-  div.image-collage.autoblocked
-  div.img-col:last-of-type
-  picture {
-  margin: 0 auto 2rem;
 }
 
 div.img-col > video {
@@ -479,29 +432,8 @@ div.img-col > video {
     margin-bottom: 1.5rem;
   }
 
-  .columns.history picture {
-    margin: 0 auto 2rem;
-  }
-
-  .columns.history picture:last-child {
-    margin: 0 auto;
-  }
-
-  /* picture in column with text */
-  .columns.history p ~ div > div.image-collage.autoblocked picture {
-    display: table;
-    width: 100%;
-  }
-
   .columns > div .img-col {
     order: unset;
-  }
-
-  .columns.history > div {
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 2rem;
   }
 
   .columns.invert-image-order-in-narrow-view > div .img-col,
@@ -518,7 +450,7 @@ div.img-col > video {
     display: none;
   }
 
-  .columns:not(.history, .text-and-image-in-column) .text-col-wrapper img:not(.video-modal) {
+  .columns:not(.text-and-image-in-column) .text-col-wrapper img:not(.video-modal) {
     height: 3.125rem;
     width: unset;
   }
@@ -542,7 +474,6 @@ div.img-col > video {
     background-position: center;
   }
 
-  main .columns.history.invert-image-order-in-narrow-view > div,
   main .columns.invert-even-col-in-narrow-view > div:nth-child(even) {
     flex-direction: row;
   }

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -241,7 +241,7 @@ div.img-col > video {
   gap: 1rem;
 }
 
-.columns.center-buttons p.button-container {
+.columns.centre-buttons p.button-container {
   justify-content: center;
 } 
 
@@ -408,7 +408,7 @@ div.img-col > video {
     width: unset;
   }
 
-  .columns.center-buttons p.button-container {
+  .columns.centre-buttons p.button-container {
     align-items: center;
     flex-direction: row;
   } 
@@ -519,9 +519,5 @@ div.img-col > video {
     flex-flow: row wrap;
     gap: 1rem;
     width: 100%;
-  }
-  
-  .columns p.button-container a.button.primary {
-    min-width: fit-content;
   }
 }

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -241,6 +241,10 @@ div.img-col > video {
   gap: 1rem;
 }
 
+.columns.center-buttons p.button-container {
+  justify-content: center;
+} 
+
 .columns.collapse.top-down.columns-2-cols {
   max-width: 100%;
 }
@@ -403,6 +407,11 @@ div.img-col > video {
     gap: 2rem;
     width: unset;
   }
+
+  .columns.center-buttons p.button-container {
+    align-items: center;
+    flex-direction: row;
+  } 
 
   .columns a.button.primary {
     min-width: 11rem;

--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -190,11 +190,7 @@ export default function decorate(block) {
                 up.classList.add('button-container');
               }
               a.classList.add('button');
-              if (a.previousElementSibling?.tagName === 'A') {
-                a.classList.add('tertiary');
-              } else {
-                a.classList.add('primary');
-              }
+              a.classList.add('primary');
             }
           });
         }

--- a/blocks/image-collage/image-collage.css
+++ b/blocks/image-collage/image-collage.css
@@ -70,7 +70,6 @@ main .image-collage .image-caption {
   margin-bottom: 1rem;
   color: var(--steel-blue);
   font-size: var(--body-font-size-xs);
-  text-align: center;
 }
 
 main .image-collage .image-title {

--- a/blocks/text/text.css
+++ b/blocks/text/text.css
@@ -77,6 +77,12 @@ main .block.text.lead {
   font-size: var(--body-font-size-xl);
 }
 
+@media (min-width: 62rem) {
+  main .block.text {
+    padding: 0;
+  }  
+}
+
 @media (min-width: 77rem) {
   main .block.text.lead {
     font-size: var(--body-font-size-xxl);

--- a/blocks/text/text.css
+++ b/blocks/text/text.css
@@ -1,3 +1,7 @@
+main .block.text {
+  padding: 0 1rem;
+}
+
 main .block.text.narrow {
   width: 100%;
   padding-right: 0;

--- a/blocks/text/text.css
+++ b/blocks/text/text.css
@@ -80,7 +80,7 @@ main .block.text.lead {
 @media (min-width: 62rem) {
   main .block.text {
     padding: 0;
-  }  
+  }
 }
 
 @media (min-width: 77rem) {

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -584,23 +584,28 @@ export function decorateTemplateAndTheme() {
  * @param {Element} element container element
  */
 export function decorateButtons(element) {
+  function onlyHasButtons(el) {
+    return [...el.childNodes].every((node) => node.tagName === 'A' || node.textContent.trim() === '');
+  }
+
   element.querySelectorAll('a').forEach((a) => {
     if (!a.closest('.no-buttons')) {
       a.title = a.title || a.textContent;
       if (a.href !== a.textContent) {
         const up = a.parentElement;
         const twoup = a.parentElement.parentElement;
+
         if (!a.querySelector('img')) {
-          if (up.childNodes.length === 1 && (up.tagName === 'P' || up.tagName === 'DIV')) {
+          if (onlyHasButtons(up) && (up.tagName === 'P' || up.tagName === 'DIV')) {
             a.className = 'button primary'; // default
             up.classList.add('button-container');
           }
-          if (up.childNodes.length === 1 && up.tagName === 'STRONG'
+          if (onlyHasButtons(up) && up.tagName === 'STRONG'
             && twoup.childNodes.length === 1 && twoup.tagName === 'P') {
             a.className = 'button primary';
             twoup.classList.add('button-container');
           }
-          if (up.childNodes.length === 1 && up.tagName === 'EM'
+          if (onlyHasButtons(up) && up.tagName === 'EM'
             && twoup.childNodes.length === 1 && twoup.tagName === 'P') {
             a.className = 'button secondary';
             twoup.classList.add('button-container');

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -120,7 +120,7 @@ function formatAutoblockedImageCaptionsForColumns(block, enclosingDiv) {
   const blockClassList = block.classList;
   const columnDiv = document.createElement('div');
 
-  if (enclosingDiv.parentElement?.classList?.contains('columns') || enclosingDiv.parentElement?.parentElement?.classLis?.contains('columns')) {
+  if (enclosingDiv.parentElement?.classList?.contains('columns') || enclosingDiv.parentElement?.parentElement?.classList?.contains('columns')) {
     columnDiv.classList = blockClassList;
     columnDiv.classList.add('img-col');
     columnDiv.appendChild(picture);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -114,19 +114,21 @@ function buildImageCollageForPicture(picture, caption, buildBlockFunction) {
   return newBlock;
 }
 
-function formatAutoblockedImageCaptions(block, enclosingDiv) {
+function formatAutoblockedImageCaptionsForColumns(block, enclosingDiv) {
   const picture = block.querySelector('picture');
   const caption = block.querySelector('p');
   const blockClassList = block.classList;
   const columnDiv = document.createElement('div');
 
-  columnDiv.classList = blockClassList;
-  columnDiv.classList.add('img-col');
-  columnDiv.appendChild(picture);
-  columnDiv.appendChild(caption);
+  if (enclosingDiv.parentElement?.classList.contains('columns') || enclosingDiv.parentElement?.parentElement?.classList.contains('columns')) {
+    columnDiv.classList = blockClassList;
+    columnDiv.classList.add('img-col');
+    columnDiv.appendChild(picture);
+    columnDiv.appendChild(caption);
 
-  enclosingDiv.classList.add('img-col-wrapper');
-  enclosingDiv.replaceChild(columnDiv, block);
+    enclosingDiv.classList.add('img-col-wrapper');
+    enclosingDiv.replaceChild(columnDiv, block);
+  }
 }
 
 function buildImageWithCaptionForPicture(parentP, picture, buildBlockFunction) {
@@ -158,7 +160,8 @@ function buildImageWithCaptionForPicture(parentP, picture, buildBlockFunction) {
         }
         // insert the new block at the position the old image was at
         enclosingDiv.replaceChild(newBlock, parentP);
-        formatAutoblockedImageCaptions(newBlock, enclosingDiv);
+
+        formatAutoblockedImageCaptionsForColumns(newBlock, enclosingDiv);
         return;
       }
 
@@ -176,7 +179,7 @@ function buildImageWithCaptionForPicture(parentP, picture, buildBlockFunction) {
         const newBlock = buildImageCollageForPicture(picture, cp, buildBlockFunction);
         newBlock.classList.add('autoblocked');
         enclosingDiv.replaceChild(newBlock, parentP);
-        formatAutoblockedImageCaptions(newBlock, enclosingDiv);
+        formatAutoblockedImageCaptionsForColumns(newBlock, enclosingDiv);
         return;
       }
     }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -114,6 +114,21 @@ function buildImageCollageForPicture(picture, caption, buildBlockFunction) {
   return newBlock;
 }
 
+function formatAutoblockedImageCaptions(block, enclosingDiv) {
+  const picture = block.querySelector('picture');
+  const caption = block.querySelector('p');
+  const blockClassList = block.classList;
+  const columnDiv = document.createElement('div');
+
+  columnDiv.classList = blockClassList;
+  columnDiv.classList.add('img-col');
+  columnDiv.appendChild(picture);
+  columnDiv.appendChild(caption);
+
+  enclosingDiv.classList.add('img-col-wrapper');
+  enclosingDiv.replaceChild(columnDiv, block);
+}
+
 function buildImageWithCaptionForPicture(parentP, picture, buildBlockFunction) {
   const enclosingDiv = parentP.parentElement;
 
@@ -143,6 +158,7 @@ function buildImageWithCaptionForPicture(parentP, picture, buildBlockFunction) {
         }
         // insert the new block at the position the old image was at
         enclosingDiv.replaceChild(newBlock, parentP);
+        formatAutoblockedImageCaptions(newBlock, enclosingDiv);
         return;
       }
 
@@ -160,6 +176,7 @@ function buildImageWithCaptionForPicture(parentP, picture, buildBlockFunction) {
         const newBlock = buildImageCollageForPicture(picture, cp, buildBlockFunction);
         newBlock.classList.add('autoblocked');
         enclosingDiv.replaceChild(newBlock, parentP);
+        formatAutoblockedImageCaptions(newBlock, enclosingDiv);
         return;
       }
     }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -120,7 +120,7 @@ function formatAutoblockedImageCaptionsForColumns(block, enclosingDiv) {
   const blockClassList = block.classList;
   const columnDiv = document.createElement('div');
 
-  if (enclosingDiv.parentElement?.classList.contains('columns') || enclosingDiv.parentElement?.parentElement?.classList.contains('columns')) {
+  if (enclosingDiv.parentElement?.classList?.contains('columns') || enclosingDiv.parentElement?.parentElement?.classLis?.contains('columns')) {
     columnDiv.classList = blockClassList;
     columnDiv.classList.add('img-col');
     columnDiv.appendChild(picture);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -108,6 +108,7 @@ function buildImageCollageForPicture(picture, caption, buildBlockFunction) {
   const captionText = caption.textContent;
   const captionP = document.createElement('p');
   captionP.innerHTML = captionText;
+  captionP.classList.add('image-caption');
   caption.remove();
   const newBlock = buildBlockFunction('image-collage', { elems: [picture, captionP] });
   newBlock.classList.add('boxy-col-1');

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -978,6 +978,10 @@ main .block.centered > div {
     display: block;
   }
 
+  main .default-content-wrapper {
+    padding: 0;
+  }
+
   /* START Section Styles START */
 
   main .section .section-container {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -582,6 +582,10 @@ main .block.centered {
   position: relative;
 }
 
+main .default-content-wrapper {
+  padding: 0 1rem;
+}
+
 /* START Section Styles START */
 
 main .section .section-container {


### PR DESCRIPTION
- Added step to rearrange autoblocked images with captions for `columns`
- Refactored `decorateButtons` to work with multiple buttons
- Moved `columns` css around and added some rules
- removed `machine-parts`, `history`
- added padding to the `text` block and `default-content-wrapper`
- added `centre-buttons` for `columns`

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes #<gh-issue-id>

Test URLs:
- Original: https://www.sunstar-foundation.org/about-us/history
- Before: https://main--sunstar-foundation--hlxsites.hlx.live/about-us/history
- After: https://img-caption-autoblocking-refactor--sunstar-foundation--hlxsites.hlx.live/about-us/history

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation
------------- | -------------
 For e.g. cards | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=0)



- [x] New variations introduced in this PR

Variation Name    | Documentation
------------- | -------------
columns(centre-buttons)  | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=2)
