### PR TITLE
Japanese Page /about-us/foundation-data

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -783,6 +783,12 @@ main .section.static .section-container h2 {
   margin: 4rem 0 1.5rem;
 }
 
+/* section - bottom-dark-border */
+main .section.bottom-dark-border .section-container div {
+  border-bottom: 2px solid var(--primary);
+  padding-bottom: 1rem;
+}
+
 /* section - margin-bottom */
 main .section.margin-bottom {
   margin-bottom: 5rem;
@@ -881,6 +887,7 @@ main .section.padded-inline > .tab-item.active > .section-container {
   box-sizing: border-box;
 }
 
+/* stylelint-disable-next-line no-descending-specificity */
 main .block.centered > div {
   margin: auto;
 }
@@ -987,10 +994,6 @@ main .block.centered > div {
     margin-bottom: 2rem;
   }
 
-  main .section.bottom-dark-border .section-container {
-    border-bottom: 2px solid var(--primary);
-  }
-
   /* section - spaced */
   main .section.spaced h2 {
     font-size: var(--heading-font-size-xl);
@@ -1008,7 +1011,7 @@ main .block.centered > div {
   /* section - large-padded */
    main .section.large-padded  > .section-container  {
     padding: 5rem 0;
-  } 
+  }
 
   /* section - narrow */
   /* stylelint-disable-next-line no-descending-specificity */


### PR DESCRIPTION
Moved the style to Mobile section to apply for all device types

Fixes #34 

Test URLs:
- Original: https://www.sunstar-foundation.org/about-us/foundation-data
- Before: https://main--sunstar-foundation--hlxsites.hlx.live/about-us/foundation-data
- After: https://issue-34-v3--sunstar-foundation--hlxsites.hlx.live/about-us/foundation-data


- [x] New variations introduced in this PR

Variation Name    | Documentation
------------- | -------------
section (border bottom)  | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/sections&index=15)
