### PR TITLE
breadcrumb importing removed from importer

### DIFF
--- a/tools/importer/import-career.js
+++ b/tools/importer/import-career.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 /* global WebImporter */
-import { createSectionMetadata } from './utils.js';
+import { createSectionMetadata, addBreadCrumb } from './utils.js';
 
 /* eslint-disable no-console, class-methods-use-this */
 
@@ -47,18 +47,6 @@ const createMetadata = (main, doc, params, mainImg) => {
 
   return meta;
 };
-
-function addBreadCrumb(doc) {
-  const breadcrumb = doc.querySelector('.section-breadcrumb');
-
-  if (breadcrumb) {
-    // Not removing breadcrumb section from here because we need to extract breadcrumb title.
-    const cells = [['Breadcrumb']];
-    const table = WebImporter.DOMUtils.createTable(cells, doc);
-    breadcrumb.after(doc.createElement('hr'));
-    breadcrumb.replaceWith(table);
-  }
-}
 
 /**
  * Extract background images from the source node and

--- a/tools/importer/import-photo-gallery.js
+++ b/tools/importer/import-photo-gallery.js
@@ -12,6 +12,8 @@
 /* global WebImporter */
 /* eslint-disable no-console, class-methods-use-this */
 
+import { addBreadCrumb } from './utils.js';
+
 const createMetadata = (main, document, params) => {
   const meta = {};
 
@@ -243,18 +245,6 @@ function extractEmbedItems(embedItems, noHrInsert) {
 function extractEmbed(document) {
   const embedItems = document.querySelectorAll('.wp-block-embed');
   extractEmbedItems(embedItems);
-}
-
-function addBreadCrumb(doc) {
-  const breadcrumb = doc.querySelector('.section-breadcrumb');
-
-  if (breadcrumb) {
-    // Not removing breadcrumb section from here because we need to extract breadcrumb title.
-    const cells = [['Breadcrumb']];
-    const table = WebImporter.DOMUtils.createTable(cells, doc);
-    breadcrumb.after(doc.createElement('hr'));
-    breadcrumb.replaceWith(table);
-  }
 }
 
 function removeCookiesBanner(document) {

--- a/tools/importer/import.js
+++ b/tools/importer/import.js
@@ -12,6 +12,8 @@
 /* global WebImporter */
 /* eslint-disable no-console, class-methods-use-this */
 
+import { addBreadCrumb } from './utils.js';
+
 const createMetadata = (main, document, params) => {
   const meta = {};
 
@@ -252,18 +254,6 @@ function extractEmbedItems(embedItems, noHrInsert) {
 function extractEmbed(document) {
   const embedItems = document.querySelectorAll('.wp-block-embed');
   extractEmbedItems(embedItems);
-}
-
-function addBreadCrumb(doc) {
-  const breadcrumb = doc.querySelector('.section-breadcrumb');
-
-  if (breadcrumb) {
-    // Not removing breadcrumb section from here because we need to extract breadcrumb title.
-    const cells = [['Breadcrumb']];
-    const table = WebImporter.DOMUtils.createTable(cells, doc);
-    breadcrumb.after(doc.createElement('hr'));
-    breadcrumb.replaceWith(table);
-  }
 }
 
 function removeCookiesBanner(document) {

--- a/tools/importer/utils.js
+++ b/tools/importer/utils.js
@@ -64,11 +64,7 @@ export function addBreadCrumb(doc) {
   const breadcrumb = doc.querySelector('.section-breadcrumb');
 
   if (breadcrumb) {
-    // Not removing breadcrumb section from here because we need to extract breadcrumb title.
-    const cells = [['Breadcrumb']];
-    const table = WebImporter.DOMUtils.createTable(cells, doc);
-    breadcrumb.after(doc.createElement('hr'));
-    breadcrumb.replaceWith(table);
+    breadcrumb.remove();
   }
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes 

Test URLs:
- Original: https://www.sunstar-foundation.org
- Before: https://main--sunstar-foundation--hlxsites.hlx.live
- After: https://breadcrumb-remove-import--sunstar-foundation--hlxsites.hlx.live

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation
------------- | -------------
 For e.g. cards | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=0)



- [ ] New variations introduced in this PR

Variation Name    | Documentation
------------- | -------------
 For e.g. cards (grid)  | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=2)
