### PR TITLE
Refactored table for awards page

### DIFF
--- a/blocks/table/table.css
+++ b/blocks/table/table.css
@@ -1,14 +1,14 @@
-main .table.inner-table span.icon {
+main .table span.icon {
     width: 70px;
     height: auto;
 }
 
-main .table.inner-table img {
+main .table img {
     height: 80px;
     width: auto;
 }
 
-main .table.inner-table.native-image-sizes img {
+main .table.native-image-sizes img {
     width: 100%;
     height: 100%;
     max-width: 100%;
@@ -19,50 +19,29 @@ main .table.block h3.table-title {
     margin-bottom: 0.5rem;
 }
 
-main .table .table-item {
-    display: grid;
-    grid-auto-flow: column;
-    grid-template-columns: auto repeat(calc(var(--row) - 1), minmax(50px, max-content));
-    grid-template-rows: repeat(var(--col), auto);
-    grid-gap: 1px;
-    margin-bottom: 1.5rem;
-    border: 1px solid var(--transparent-grey-light-color);
-    background-color: var(--transparent-grey-light-color);
-}
-
-main .table .table-item div {
-    font-size: var(--body-font-size-s);
-    line-height: 1.7em;
-    font-weight: var(--font-weight-medium);
-    padding: 0.5em 1em;
-    text-align: center;
-    vertical-align: middle;
-    background-color: var(--white);
-}
-
 main .section .table.block p.table-annotation {
     margin-bottom: 1.5rem;
 }
 
-main .table.inner-table table {
+main .table table {
     background-color: var(--white);
     border-collapse: collapse;
     overflow-x: auto;
     display: block;
-    margin-bottom: 1.5rem;
+    padding-bottom: 1.5rem;
 }
 
-main .table.inner-table .table-item {
+main .table .table-item {
     display: unset;
     margin-bottom: unset;
     border: unset;
 }
 
-main .table.inner-table .table-item div {
+main .table .table-item div {
     padding: unset;
 }
 
-main .table.inner-table table td {
+main .table:not(.text-table) table td {
     font-size: 0.88rem;
     line-height: 1.7em;
     text-align: center;
@@ -71,7 +50,7 @@ main .table.inner-table table td {
     vertical-align: middle;
 }
 
-main .table.inner-table table td p {
+main .table table td p {
     font-size: 0.88rem;
     line-height: 1.7em;
     margin-bottom: 0;
@@ -187,13 +166,14 @@ main .table.text-table table tr td a .icon {
     width: 1.5em;
 }
 
-main .table.inner-table.no-vertical-borders table td {
+/* stylelint-disable-next-line no-descending-specificity */
+main .table.no-vertical-borders table td {
     border-left: unset;
     border-right: unset;
     border-top: unset;
 }
 
-main .table.inner-table.text-align-left table tr td {
+main .table.text-align-left table tr td {
     text-align: left;
 }
 
@@ -203,15 +183,15 @@ main .table.text-table table tr td:first-child {
     line-height: 1.5rem;
 }
 
-main .table.inner-table table tbody tr:first-of-type {
+main .table:not(.text-table) table tbody tr:first-of-type {
     background: var(--transparent-blue-light-color);
 }
 
-main .table.inner-table.no-head table tbody tr:first-of-type {
+main .table.no-head table tbody tr:first-of-type {
     background: unset;
 }
 
-main .table.inner-table.small-first-col table tr td:first-child {
+main .table.small-first-col table tr td:first-child {
     flex-basis: 10rem;
     flex-grow: 0;
     text-align: center;

--- a/blocks/table/table.css
+++ b/blocks/table/table.css
@@ -1,11 +1,17 @@
-main .table.block.inner-table span.icon {
+main .table.inner-table span.icon {
     width: 70px;
     height: auto;
 }
 
-main .table.block.inner-table img {
+main .table.inner-table img {
     height: 80px;
     width: auto;
+}
+
+main .table.inner-table.native-image-sizes img {
+    width: 100%;
+    height: 100%;
+    max-width: 100%;
 }
 
 main .table.block h3.table-title {
@@ -61,7 +67,7 @@ main .table.inner-table table td {
     line-height: 1.7em;
     text-align: center;
     padding: 0.5em 1em;
-    border-bottom: 1px solid var(--transparent-grey-light-color);
+    border: 1px solid var(--transparent-grey-light-color);
     vertical-align: middle;
 }
 
@@ -181,7 +187,13 @@ main .table.text-table table tr td a .icon {
     width: 1.5em;
 }
 
-main .table.inner-table table tr td {
+main .table.inner-table.no-vertical-borders table td {
+    border-left: unset;
+    border-right: unset;
+    border-top: unset;
+}
+
+main .table.inner-table.text-align-left table tr td {
     text-align: left;
 }
 
@@ -191,7 +203,15 @@ main .table.text-table table tr td:first-child {
     line-height: 1.5rem;
 }
 
-main .table.inner-table table tr td:first-child {
+main .table.inner-table table tbody tr:first-of-type {
+    background: var(--transparent-blue-light-color);
+}
+
+main .table.inner-table.no-head table tbody tr:first-of-type {
+    background: unset;
+}
+
+main .table.inner-table.small-first-col table tr td:first-child {
     flex-basis: 10rem;
     flex-grow: 0;
     text-align: center;

--- a/blocks/table/table.css
+++ b/blocks/table/table.css
@@ -1,3 +1,13 @@
+main .table.block.inner-table span.icon {
+    width: 70px;
+    height: auto;
+}
+
+main .table.block.inner-table img {
+    height: 80px;
+    width: auto;
+}
+
 main .table.block h3.table-title {
     font-size: 1rem;
     margin-bottom: 0.5rem;
@@ -28,13 +38,6 @@ main .section .table.block p.table-annotation {
     margin-bottom: 1.5rem;
 }
 
-main .section .table.inner-table img {
-    vertical-align: middle;
-    border-style: none;
-    width: 9.375rem;
-    max-width: unset;
-}
-
 main .table.inner-table table {
     background-color: var(--white);
     border-collapse: collapse;
@@ -58,7 +61,7 @@ main .table.inner-table table td {
     line-height: 1.7em;
     text-align: center;
     padding: 0.5em 1em;
-    border: 1px solid var(--transparent-grey-light-color);
+    border-bottom: 1px solid var(--transparent-grey-light-color);
     vertical-align: middle;
 }
 
@@ -110,28 +113,6 @@ main .multiple-table .flat-table {
     min-width: 0;
     word-break: break-word;
     overflow-wrap: break-word;
-}
-
-@media (min-width: 62rem) {
-    main .multiple-table {
-        display: flex;
-        flex-flow: row nowrap;
-    }
-
-    main .table .table-item {
-        display: inline-grid;
-        grid-auto-flow: row;
-        grid-template-columns: repeat(var(--col), auto);
-        grid-template-rows: repeat(var(--row), auto);
-    }
-
-    main .table .table-item .table-head {
-        text-align: center;
-    }
-
-    main .section .table.block p.table-annotation {
-        margin-bottom: 2rem;
-    }
 }
 
 /* Text Table varient */
@@ -200,18 +181,20 @@ main .table.text-table table tr td a .icon {
     width: 1.5em;
 }
 
+main .table.inner-table table tr td {
+    text-align: left;
+}
+
 main .table.text-table table tr td:first-child {
     color: var(--transparent-grey-color);
     font-size: var(--body-font-size-m);
     line-height: 1.5rem;
 }
 
-main .table.inner-table table tbody tr:first-of-type {
-    background: var(--transparent-blue-light-color);
-}
-
-main .table.inner-table.lastline-leftalign table tr:last-of-type td {
-    text-align: left;
+main .table.inner-table table tr td:first-child {
+    flex-basis: 10rem;
+    flex-grow: 0;
+    text-align: center;
 }
 
 main .table.block .table-title h4 {
@@ -219,6 +202,26 @@ main .table.block .table-title h4 {
 }
 
 @media (min-width: 62rem) {
+    main .multiple-table {
+        display: flex;
+        flex-flow: row nowrap;
+    }
+
+    main .table .table-item {
+        display: inline-grid;
+        grid-auto-flow: row;
+        grid-template-columns: repeat(var(--col), auto);
+        grid-template-rows: repeat(var(--row), auto);
+    }
+
+    main .table .table-item .table-head {
+        text-align: center;
+    }
+
+    main .section .table.block p.table-annotation {
+        margin-bottom: 2rem;
+    }
+
     main .table.text-table table tr {
         flex-direction: row;
     }

--- a/blocks/table/table.js
+++ b/blocks/table/table.js
@@ -1,3 +1,5 @@
+import { readBlockConfig } from '../../scripts/lib-franklin.js';
+
 function buildMutipleTables(block) {
   const mainContent = block.parentNode.parentNode;
   if (mainContent.querySelectorAll(':scope > .flat-table').length < 2) return;
@@ -33,39 +35,45 @@ function buildMutipleTables(block) {
 }
 
 export default async function decorate(block) {
+  const blockConfig = readBlockConfig(block);
+  const missingCfgs = [blockConfig.title, blockConfig.annotation].filter((x) => !x).length;
   const tableDiv = document.createElement('div');
   tableDiv.classList.add('table-item');
-  const tableTitle = document.createElement('h3');
-  tableTitle.classList.add('table-title');
   const tableAnnotation = document.createElement('p');
   tableAnnotation.classList.add('table-annotation');
-  [...block.children].forEach((child, i) => {
-    if (i === 0) {
-      tableTitle.innerHTML = [...child.children][1].innerHTML;
-    } else if (i === 1) {
-      tableAnnotation.innerHTML = [...child.children][1].innerHTML;
-    } else {
-      if (tableDiv.getAttribute('style') === null) {
-        const rowLength = ([...block.children].length - 2).toString();
-        const colLength = ([...child.children].length - 1).toString();
-        tableDiv.setAttribute('style', `--row:${rowLength};--col:${colLength}`);
-      }
-      [...child.children].forEach((childDiv, x) => {
-        if (x) {
-          if (i === 2) childDiv.classList.add('table-head');
-          tableDiv.append(childDiv);
-        }
-      });
+  const tableTitle = document.createElement('h3');
+  tableTitle.classList.add('table-title');
+
+  if (blockConfig.title) {
+    tableTitle.innerHTML = blockConfig.title;
+  }
+
+  if (blockConfig.annotation) {
+    tableAnnotation.innerHTML = blockConfig.annotation;
+  }
+
+  const tableChild = [...block.children].filter((x) => x.innerText.trim().toLowerCase().startsWith('table'))[0];
+  if (tableDiv.getAttribute('style') === null) {
+    const rowLength = ([...block.children].length - 2 + missingCfgs).toString();
+    const colLength = (tableChild.children.length - 1).toString();
+    tableDiv.setAttribute('style', `--row:${rowLength};--col:${colLength}`);
+  }
+
+  [...tableChild.children].forEach((childDiv, x) => {
+    if (x) {
+      childDiv.classList.add('table-head');
+      tableDiv.append(childDiv);
     }
   });
-  if (tableTitle.innerHTML === '') {
+
+  if (!blockConfig.title) {
     block.replaceChildren(tableDiv);
-    if (tableAnnotation.innerHTML !== '') block.append(tableAnnotation);
   } else {
     block.replaceChildren(tableTitle);
     block.append(tableDiv);
-    if (tableAnnotation.innerHTML !== '') block.append(tableAnnotation);
   }
+
+  if (blockConfig.annotation) block.append(tableAnnotation);
   if (block.classList.contains('flat')) block.parentElement.classList.add('flat-table');
   buildMutipleTables(block);
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

- Made it so `inner-table` variant is the default
- Tables no longer always require title and captions even if they are empty
- Changed styles around to re-introduce some variants that were no longer working

Fixes #<gh-issue-id>

Test URLs:
- Original: https://www.sunstar-foundation.org/award
- Before: https://main--sunstar-foundation--hlxsites.hlx.live/award
- After: https://inner-table-refactor--sunstar-foundation--hlxsites.hlx.live/award


- [x] New variations introduced in this PR

Variation Name    | Documentation
------------- | -------------
 Table variants  | [doc-link](https://inner-table-refactor--sunstar-foundation--hlxsites.hlx.page/sidekick/blocks/tables)
