### PR TITLE
Updating the logic for reflecting description onto the form for any of the fields for customer future use

### DIFF
--- a/blocks/form/form.css
+++ b/blocks/form/form.css
@@ -11,7 +11,7 @@
 
 main .form,
 main .section.form-container .default-content-wrapper {
-  max-width: 560px;
+  max-width: 720px;
 }
 
 main .section.form-container .default-content-wrapper {

--- a/blocks/form/form.css
+++ b/blocks/form/form.css
@@ -96,6 +96,10 @@ main .form select:focus {
   box-shadow: none;
 }
 
+main .form-text-wrapper div {
+  font-size: var(--body-font-size-s);
+}
+
 main .form .invalid>input:hover,
 main .form .invalid>textarea:hover,
 main .form .invalid>select:hover {

--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -374,6 +374,11 @@ async function createForm(formURL) {
         fieldWrapper.append(msgEl);
         el.addEventListener('blur', () => validateField(el, fd));
       }
+      if (fd.Description) {
+        const des = document.createElement('div');
+        des.textContent = fd.Description;
+        fieldWrapper.append(des);
+      }
     };
 
     switch (fd.Type) {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes #98 

Test URLs:
- Original: https://www.sunstar-foundation.org/en/awards/perio-link/submit-your-video
- Before: https://main--sunstar-foundation--hlxsites.hlx.live/en/awards/perio-link/submit-your-video
- After: https://issue98-forms-captcha--sunstar-foundation--hlxsites.hlx.live/en/awards/perio-link/submit-your-video

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation
------------- | -------------
 For e.g. cards | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=0)



- [ ] New variations introduced in this PR

Variation Name    | Documentation
------------- | -------------
 For e.g. cards (grid)  | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=2)
