### PR TITLE
Light Background variant added for text block

### DIFF
--- a/blocks/text/text.css
+++ b/blocks/text/text.css
@@ -77,6 +77,11 @@ main .block.text.lead {
   font-size: var(--body-font-size-xl);
 }
 
+main .block.text.light-background {
+  background-color: var(--transparent-blue-light-color);
+  padding: 1rem;
+}
+
 @media (min-width: 62rem) {
   main .block.text {
     padding: 0;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes 

Test URLs:
- Original: https://www.sunstar-foundation.org/oral-care/for-healthcare
- Before: https://main--sunstar-foundation--hlxsites.hlx.live/oral-care/for-healthcare
- After: https://text-light-blue--sunstar-foundation--hlxsites.hlx.live/oral-care/for-healthcare

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation
------------- | -------------
 For e.g. cards | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=0)



- [ ] New variations introduced in this PR

Variation Name    | Documentation
------------- | -------------
 For e.g. cards (grid)  | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=2)
