### PR TITLE
Assets Sidekick Addon for videos

### DIFF
--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -7,6 +7,12 @@
 import { loadScript } from '../../scripts/scripts.js';
 import { loadCSS } from '../../scripts/lib-franklin.js';
 
+const getDefaultEmbed = (url) => `<div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%;">
+        <iframe src="${url.href}" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" allowfullscreen=""
+          scrolling="no" allow="encrypted-media" title="Content from ${url.hostname}" loading="lazy">
+        </iframe>
+      </div>`;
+
 const embedYoutube = (url, isLite) => {
   const usp = new URLSearchParams(url.search);
   let suffix = '';
@@ -44,7 +50,7 @@ const embedYoutube = (url, isLite) => {
       embed += url.search;
     }
     embedHTML = `<div style="left: 0; width: 100%; height: 0; position: relative; padding-bottom: 56.25%;">
-        <iframe src="https://www.youtube.com${vid ? `/embed/${vid}?rel=0&v=${vid}${suffix}` : embed}" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;" 
+        <iframe src="https://www.youtube.com${vid ? `/embed/${vid}?rel=0&v=${vid}${suffix}` : embed}" style="border: 0; top: 0; left: 0; width: 100%; height: 100%; position: absolute;"
         allow="autoplay; fullscreen; picture-in-picture; encrypted-media; accelerometer; gyroscope; picture-in-picture" scrolling="no" title="Content from Youtube" loading="lazy"></iframe>
       </div>`;
   }
@@ -113,6 +119,9 @@ const loadEmbed = (block, grandChilds, link) => {
   if (config) {
     block.innerHTML = config.embed(url, isLite, config.type);
     block.classList = `block embed embed-${config.match[0]}`;
+  } else {
+    block.innerHTML = getDefaultEmbed(url);
+    block.classList = 'block embed';
   }
   block.classList.add('embed-is-loaded');
 

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -8,6 +8,15 @@
       "environments": [ "edit" ],
       "url": "/tools/sidekick/library.html",
       "includePaths": [ "**.docx**" ]
+    },
+    {
+      "id": "asset-library",
+      "title": "My Assets",
+      "environments": ["edit"],
+      "url": "https://experience.adobe.com/solutions/CQ-assets-selectors/static-assets/resources/franklin/asset-selector.html",
+      "isPalette": true,
+      "includePaths": ["**.docx**"],
+      "paletteRect": "top: 50px; bottom: 10px; right: 10px; left: auto; width:400px; height: calc(100vh - 60px)"
     }
   ]
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes #51 

Test URLs:
- Before: https://main--sunstar-foundation--hlxsites.hlx.live/_drafts/satyam/all-videos
- After: https://assets--sunstar-foundation--hlxsites.hlx.live/_drafts/satyam/all-videos

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation
------------- | -------------
 For e.g. cards | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=0)



- [ ] New variations introduced in this PR

Variation Name    | Documentation
------------- | -------------
 For e.g. cards (grid)  | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=2)
