### PR TITLE
Fix robots.txt by removing the Disallow entries.

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,16 +1,5 @@
 User-agent: *
-Disallow: /_drafts/
-Disallow: /_tools/
-Disallow: /sidekick/
-Disallow: /fragments/
-Disallow: /**/fragments/
-Disallow: /nav
-Disallow: /**/nav
-Disallow: /footer
-Disallow: /**/footer
-Disallow: /thankyou
-Disallow: /**/thankyou
-Disallow: /search
-Disallow: /**/search
+Allow: /
 
 Sitemap: https://www.sunstar-foundation.org/sitemap.xml
+


### PR DESCRIPTION
These are now in metadata.xlsx or as direct metadata on affected pages in the documents.

Disallow in robots.txt is not a way to keep a page out of a search engine. For more info see:
  https://developers.google.com/search/docs/crawling-indexing/robots/intro

Fixes: #138

Test URLs:
- Original: https://www.sunstar-foundation.org/
- Before: https://main--sunstar-foundation--hlxsites.hlx.live/
- After: https://fix-robots--sunstar-foundation--hlxsites.hlx.live/
