### PR TITLE
Breadcrumb Changes wrt to redirect pages

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -258,6 +258,45 @@ export async function fetchPlaceholders(locale = 'en') {
 }
 
 /**
+ * Fetch Redirects
+ * @returns
+ */
+export async function fetchRedirects() {
+  window.redirects = window.redirects || {};
+  const REDIRECTION_KEY = 'redirect';
+  const loaded = window.redirects[`${REDIRECTION_KEY}-loaded`];
+
+  if (!loaded) {
+    window.redirects[`${REDIRECTION_KEY}-loaded`] = new Promise((resolve, reject) => {
+      fetch('/redirects.json')
+        .then((resp) => {
+          if (resp.ok) {
+            return resp.json();
+          }
+          throw new Error(`${resp.status}: ${resp.statusText}`);
+        })
+        .then((json) => {
+          const redirects = {};
+
+          json.data.forEach((entry) => {
+            redirects[entry.Source] = entry.Destination;
+          });
+
+          window.redirects[REDIRECTION_KEY] = redirects;
+          resolve();
+        }).catch((error) => {
+          // Error While Loading redirects
+          window.redirects[REDIRECTION_KEY] = {};
+          reject(error);
+        });
+    });
+  }
+
+  await window.redirects[`${REDIRECTION_KEY}-loaded`];
+  return window.redirects[REDIRECTION_KEY];
+}
+
+/**
  * Decorates a block.
  * @param {Element} block The block element
  */


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes 

Test URLs:
- Original: https://www.sunstar-foundation.org/archives/dentistry/news/%e3%80%90%e6%9c%80%e6%96%b0%e3%80%91%e5%8f%b0%e9%a2%a814%e5%8f%b7%e3%81%ab%e3%82%88%e3%82%8b%e8%a8%ba%e7%99%82%e3%81%b8%e3%81%ae%e5%bd%b1%e9%9f%bf%e3%81%ab%e3%81%a4%e3%81%84%e3%81%a6
- Before: https://main--sunstar-foundation--hlxsites.hlx.live/archives/dentistry/news/20220920
- After: https://breadcrumb-changes--sunstar-foundation--hlxsites.hlx.live/archives/dentistry/news/20220920

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation
------------- | -------------
 For e.g. cards | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=0)



- [ ] New variations introduced in this PR

Variation Name    | Documentation
------------- | -------------
 For e.g. cards (grid)  | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=2)
