### PR TITLE
Autoblock video with poster

### DIFF
--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -142,6 +142,19 @@ const loadEmbed = (block, grandChilds, link, existingClassList) => {
     block.classList = `block embed embed-${config.match[0]}`;
   } else {
     block.innerHTML = getDefaultEmbed(url);
+    // Pass the video config to the iframe
+    const videoConfig = {
+      autoplay: 'muted',
+    };
+    window.addEventListener('message', (event) => {
+      switch (event.data) {
+        case 'config':
+          event.source.window.postMessage(JSON.stringify(videoConfig), '*');
+          break;
+        default:
+          break;
+      }
+    });
     block.classList = 'block embed';
   }
   block.classList.add('embed-is-loaded');

--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -144,7 +144,7 @@ const loadEmbed = (block, grandChilds, link, existingClassList) => {
     block.innerHTML = getDefaultEmbed(url);
     // Pass the video config to the iframe
     const videoConfig = {
-      autoplay: 'muted',
+      autoplay: 'any',
     };
     window.addEventListener('message', (event) => {
       switch (event.data) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -282,6 +282,56 @@ function getUrlExtension(url) {
 }
 
 /**
+ * Checks if an anchor element is a video with poster.
+ * The anchor element must have a predecessor "p" tag with a single "picture" tag.
+ * The "p" tag must have the video link marker as text content.
+ * @param {Element} anchorTag The anchorTag
+ * @param {string} videoLinkMarker The marker to identify video with poster
+ * @returns {boolean} Whether the anchor tag is a video with poster
+ * @private
+ */
+function isVideoWithPoster(anchorTag, videoLinkMarker = '//Video Link//') {
+  // if the element is not an anchor, it can't be a video with poster
+  if (anchorTag.tagName !== 'A') return false;
+
+  // if the element is an anchor, but doesn't have the video link marker as text content,
+  // it can't be a video with poster
+  if (anchorTag.textContent.trim() !== videoLinkMarker) {
+    return false;
+  }
+
+  // if the element is an anchor with the video link marker as text content,
+  // it's can be a video with poster
+  if (anchorTag.parentNode && anchorTag.parentNode.tagName.toLowerCase() === 'p') {
+    // Get the predecessor "p" tag
+    const predecessorPTag = anchorTag.parentNode.previousElementSibling;
+
+    // Check if the predecessor "p" tag exists and has a single "picture" tag
+    return predecessorPTag && predecessorPTag.tagName.toLowerCase() === 'p'
+      && predecessorPTag.getElementsByTagName('picture').length === 1;
+  }
+
+  return false;
+}
+
+/**
+ * Decorates video with poster anchors
+ * @param {*} videoWithPosterAnchors The anchors to decorate
+ */
+function decorateVideoWithPoster(videoWithPosterAnchors) {
+  if (videoWithPosterAnchors.length) {
+    videoWithPosterAnchors.forEach((a) => {
+      const parentP = a.parentNode;
+      const enclosingDiv = parentP.parentNode;
+      const picture = a.parentNode.previousElementSibling.querySelector('picture');
+      a.classList.add('video-with-poster');
+      const embedBlock = buildBlock('embed', { elems: [picture, a] });
+      enclosingDiv.replaceChild(embedBlock, parentP);
+    });
+  }
+}
+
+/**
  * decorates anchors
  * for styling updates via CSS
  * @param {Element} element The element to decorate
@@ -291,6 +341,9 @@ export function decorateAnchors(element = document) {
   const anchors = element.getElementsByTagName('a');
   decorateVideoLinks(Array.from(anchors).filter(
     (a) => a.href.includes('youtu'),
+  ));
+  decorateVideoWithPoster(Array.from(anchors).filter(
+    (a) => isVideoWithPoster(a),
   ));
   decorateExternalAnchors(Array.from(anchors).filter(
     (a) => a.href && (!a.href.match(`^http[s]*://${window.location.host}/`)

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -325,6 +325,8 @@ function decorateVideoWithPoster(videoWithPosterAnchors) {
       const enclosingDiv = parentP.parentNode;
       const picture = a.parentNode.previousElementSibling.querySelector('picture');
       a.classList.add('video-with-poster');
+      a.classList.remove('button');
+      a.classList.remove('primary');
       const embedBlock = buildBlock('embed', { elems: [picture, a] });
       enclosingDiv.replaceChild(embedBlock, parentP);
     });

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -503,7 +503,7 @@ button {
     border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
 
-a.button.primary {
+a.button.primary:not(.video-with-poster) {
   background: var(--secondary);
   color: var(--white);
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -503,7 +503,7 @@ button {
     border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
 
-a.button.primary:not(.video-with-poster) {
+a.button.primary {
   background: var(--secondary);
   color: var(--white);
 }


### PR DESCRIPTION
Auto-blocks an image followed by url with text `//Video Link//` into an `embed` block with poster.
Example:
![image](https://github.com/hlxsites/sunstar-foundation/assets/1191451/0046cbef-bf0c-47ba-b3d6-ff285c5dafc9)

gets auto blocked as

![image](https://github.com/hlxsites/sunstar-foundation/assets/1191451/cb727a12-f186-4e89-83c1-b91ae282222b)


Test URLs:
- Original: https://www.sunstar-foundation.org/<path>
- Before: https://main--sunstar-foundation--hlxsites.hlx.live/for-healthcare-info/education
- After: https://video-poster--sunstar-foundation--hlxsites.hlx.live/for-healthcare-info/education

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation
------------- | -------------
 For e.g. cards | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=0)



- [ ] New variations introduced in this PR

Variation Name    | Documentation
------------- | -------------
 For e.g. cards (grid)  | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=2)
