### PR TITLE
List Block changes different path used

### DIFF
--- a/blocks/list/list.js
+++ b/blocks/list/list.js
@@ -7,7 +7,7 @@ const blockJson = {
   news: {
     filerResults: (data, currPath) => data.filter((entry) => entry.publisheddate
       && entry.path !== currPath
-      && (entry.path.includes('/archives/dentistry/news/')))
+      && (entry.path.includes('/dentistry/news/')))
       .sort((x, y) => y.publisheddate - x.publisheddate),
     resultsPerPage: 12,
     titlePlaceHolderKey: 'news-page-title-text',


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes 

Test URLs:
- Original: https://www.sunstar-foundation.org/dentistry/news
- Before: https://main--sunstar-foundation--hlxsites.hlx.live/dentistry/news
- After: https://list-change--sunstar-foundation--hlxsites.hlx.live/dentistry/news

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation
------------- | -------------
 For e.g. cards | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=0)



- [ ] New variations introduced in this PR

Variation Name    | Documentation
------------- | -------------
 For e.g. cards (grid)  | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=2)
