### PR TITLE
 new carousel variant with text overlapping the background image  and with no swiper control .

### DIFF
--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -50,6 +50,10 @@
   object-fit: cover;
 }
 
+.carousel.bgpic img {
+  height: auto;
+}
+
 .carousel.small img {
   height: 6rem;
   width: 6rem;

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -24,7 +24,6 @@
   transition: none;
 }
 
-
 .carousel .text-item {
   padding: 1.5rem 1rem 5.5rem;
   opacity: 0;
@@ -183,6 +182,10 @@
   justify-content: center;
 }
 
+.carousel.bgpic .control-container {
+  display:none;
+}
+
 .carousel .swip-pagination {
   display: inline-flex;
   padding: 0 1.5rem;
@@ -251,12 +254,16 @@ main .section.carousel-container {
     height: unset;
   }
 
-  .carousel.new .text {
+  .carousel.bgpic .text-item {
+    width: auto;
+  }
+
+  .carousel.bgpic .text {
     z-index: 999;
+    flex-basis: 50%;
     background: var(--primary-08-transparency);
     width: 32rem;
     left: 4rem;
-    flex-basis: 46%;
     top: 4rem;
     height: 22rem;
   }
@@ -276,7 +283,7 @@ main .section.carousel-container {
     position: absolute;
   }
 
-  .carousel.new .image{
+  .carousel.bgpic .image{
     left: 0;
     height: 30.125rem;
   }
@@ -320,7 +327,7 @@ main .section.carousel-container {
     width: 30rem;
   }
 
-  .carousel.new .text-item {
+  .carousel.bgpic .text-item {
     margin-left: 2rem;
   }
 
@@ -328,12 +335,23 @@ main .section.carousel-container {
     width: 35rem;
   }
 
+  .carousel.bgpic .text {
+    z-index: 999;
+    background: var(--primary-08-transparency);
+    width: 32rem;
+    left: 4rem;
+    flex-basis: 46%;
+    top: 4rem;
+    height: 22rem;
+  }
+
+  .carousel.bgpic .image {
+    left: 0;
+    height: 30.125rem;
+  }
 
   .carousel .control-container {
     width: 100%;
   }
 
-  .carousel.new .control-container {
-    display:none;
-  }
 }

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -51,7 +51,7 @@
 }
 
 .carousel.bgpic img {
-  height: auto;
+  height: 100%;
 }
 
 .carousel.small img {

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -259,7 +259,7 @@ main .section.carousel-container {
   }
 
   .carousel.bgpic .text {
-    z-index: 999;
+    z-index: 10;
     flex-basis: 50%;
     background: var(--primary-08-transparency);
     width: 32rem;
@@ -336,7 +336,7 @@ main .section.carousel-container {
   }
 
   .carousel.bgpic .text {
-    z-index: 999;
+    z-index: 10;
     background: var(--primary-08-transparency);
     width: 32rem;
     left: 4rem;

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -251,6 +251,16 @@ main .section.carousel-container {
     height: unset;
   }
 
+  .carousel.new .text {
+    z-index: 999;
+    background: var(--primary-08-transparency);
+    width: 32rem;
+    left: 4rem;
+    flex-basis: 46%;
+    top: 4rem;
+    height: 22rem;
+  }
+
   .carousel.small {
     position: relative;
     left: 25%;
@@ -264,6 +274,11 @@ main .section.carousel-container {
     left: calc(50% - 3.875rem);
     height: 28.125rem;
     position: absolute;
+  }
+
+  .carousel.new .image{
+    left: 0;
+    height: 30.125rem;
   }
 
 
@@ -305,6 +320,10 @@ main .section.carousel-container {
     width: 30rem;
   }
 
+  .carousel.new .text-item {
+    margin-left: 2rem;
+  }
+
   .carousel.small .text-item {
     width: 35rem;
   }
@@ -312,5 +331,9 @@ main .section.carousel-container {
 
   .carousel .control-container {
     width: 100%;
+  }
+
+  .carousel.new .control-container {
+    display:none;
   }
 }

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -31,6 +31,10 @@
   height: 100%;
 }
 
+.carousel.bgpic .text-item {
+  padding: 1.5rem 1rem;
+}
+
 .carousel .text {
   color: var(--white);
   display: flex;
@@ -256,6 +260,13 @@ main .section.carousel-container {
 
   .carousel.bgpic .text-item {
     width: auto;
+    margin-left: 2rem;
+    margin-right: 1rem;
+    padding: 1.5rem 1rem 5.5rem;
+  }
+
+  .carousel.bgpic .text-item > p {
+  font-size: var(--body-font-size-s);
   }
 
   .carousel.bgpic .text {
@@ -265,7 +276,6 @@ main .section.carousel-container {
     width: 32rem;
     left: 4rem;
     top: 4rem;
-    height: 22rem;
   }
 
   .carousel.small {
@@ -329,6 +339,7 @@ main .section.carousel-container {
 
   .carousel.bgpic .text-item {
     margin-left: 2rem;
+    margin-right: 1rem;
   }
 
   .carousel.small .text-item {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes #<gh-issue-id>

Test URLs:
- Original: https://www.sunstar-foundation.org/dentistry
- Before: https://main--sunstar-foundation--hlxsites.hlx.live/_drafts/ritwik/test
- After: https://bgpiccarousel--sunstar-foundation--hlxsites.hlx.page/_drafts/ritwik/test

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation
------------- | -------------
 For e.g. cards | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=0)



- [ ] New variations introduced in this PR

Variation Name    | Documentation
------------- | -------------
 For e.g. cards (grid)  | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=2)
