### PR TITLE
Small styling change on Cards mobile view of advice-materials page

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -190,6 +190,10 @@ main .cards.features-items h6 {
   margin: unset;
 }
 
+.cards.toc-content .cards-card-image {
+  height: unset;
+}
+
 /* Styles for info points cards */
 main .cards.info-points .cards-card-body * {
   text-align: left;
@@ -433,11 +437,6 @@ main .cards.video-modal .cards-card-image::after {
     margin: 0 auto;
     font-size: 14px;
     color: var(--transparent-grey-color-2);
-  }
-
-  /* Styles for toc-content cards */
-  .cards.toc-content .cards-card-image {
-    height: unset;
   }
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes #183 

Test URLs:
- Original: https://www.sunstar-foundation.org/for-healthcare-info/education/advice-materials
- Before: https://main--sunstar-foundation--hlxsites.hlx.live/for-healthcare-info/education/advice-materials
- After: https://issue-183--sunstar-foundation--hlxsites.hlx.live/for-healthcare-info/education/advice-materials


