### PR TITLE
Migrate "native-image-sizes" & Forms Variants from sunstar.com

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -87,6 +87,10 @@
   width: 100%;
 }
 
+.columns.native-image-sizes img {
+  width: auto;
+}
+
 .columns.native-image-sizes picture {
   display: block;
   text-align: center;
@@ -171,16 +175,16 @@
   border-radius: 50%;
 }
 
-.columns.text-and-image-in-column > div div.text-col img {
-  height: 100%;
-  width: 100%;
-  object-fit: cover;
-}
-
-.columns.columns:not(.native-image-sizes) .text-col-wrapper img {
+.columns:not(.native-image-sizes) .text-col-wrapper img {
   width: 100%;
   height: auto;
   vertical-align: middle;
+}
+
+.columns:not(.native-image-sizes).text-and-image-in-column > div div.text-col img {
+  height: 100%;
+  width: 100%;
+  object-fit: cover;
 }
 
 .columns.constrain-width > div > div.img-col {

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -97,6 +97,10 @@
   width: auto;
 }
 
+.columns.native-image-sizes.align-left-native-image picture {
+  text-align: left;
+}
+
 .columns:not(.native-image-sizes) img,
 .columns:not(.native-image-sizes) div.image-collage.autoblocked {
   width: 100%;

--- a/blocks/form/form.css
+++ b/blocks/form/form.css
@@ -17,7 +17,12 @@ main .section.form-container .default-content-wrapper {
 main .section.form-container .default-content-wrapper {
   margin: auto;
 }
- 
+
+main .form.narrower,
+main .section.narrower.form-container .default-content-wrapper {
+  max-width: 560px;
+}
+
 main .form {
   margin: 0 auto 120px;
 }


### PR DESCRIPTION
Fixes #206

Test URLs:
- Original: https://www.sunstar-foundation.org/en/about-us/hiroo-kaneda-grant
- Before: https://main--sunstar-foundation--hlxsites.hlx.live/en/about-us/hiroo-kaneda-grant
- After: https://issue-206--sunstar-foundation--hlxsites.hlx.live/en/about-us/hiroo-kaneda-grant

- [x] New variations introduced in this PR

Variation Name    | Documentation
------------- | -------------
 Columns (native-image-sizes)  | [doc-link](https://issue-206--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/columns&index=5)
 Forms (narrower)  | [doc-link](https://issue-206--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/forms&index=1)
 Columns (Left Aligned native image)  | [doc-link](https://issue-206--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/columns&index=6)
