### PR TITLE
https://www.sunstar-foundation.org/en/about-us/history - UAT feedback plus CSS changes for text within Picture element to match the original page

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -75,6 +75,24 @@
   margin-left: 0;
 }
 
+.columns.text-and-image-in-column > div > div p:has(picture) {
+  color: rgba(51 61 70 / 50%);
+  margin-bottom: 1rem;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.columns.text-layout > div > div > div {
+  font-size: var(--body-font-size-l);
+}
+
+.columns.text-and-image-in-column > div > div:not(:has(p)):has(picture) {
+  color: rgba(51 61 70 / 50%);
+  margin-bottom: 1rem;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
 .columns.highlight {
   background-color: var(--transparent-blue-light-color);
   padding: 1rem 2rem;
@@ -214,10 +232,6 @@
 .columns.text-layout > div > div h2 {
   font-size: var(--heading-font-size-mxl);
   margin: 0;
-}
-
-.columns.text-layout > div > div > div {
-  font-size: var(--body-font-size-l);
 }
 
 .columns.invert-even-col-in-narrow-view > div:nth-child(even) {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes #221 

Test URLs:
- Original: https://www.sunstar-foundation.org/en/about-us/history
- Before: https://main--sunstar-foundation--hlxsites.hlx.page/en/about-us/history
- After: https://issue221-uat-feedback--sunstar-foundation--hlxsites.hlx.page/en/about-us/history

- [ ] New Blocks introduced in this PR
      If yes, please provide details below

Block Name    | Documentation
------------- | -------------
 For e.g. cards | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=0)



- [ ] New variations introduced in this PR

Variation Name    | Documentation
------------- | -------------
 For e.g. cards (grid)  | [doc-link](https://main--sunstar-foundation--hlxsites.hlx.page/tools/sidekick/library.html?plugin=blocks&path=/sidekick/blocks/cards&index=2)
